### PR TITLE
Better precision in painting

### DIFF
--- a/iview
+++ b/iview
@@ -332,11 +332,8 @@ class Viewer(QW):
 
         dc.fillRect(self.tx+1, self.ty+1, self.img.width()*self.scale-2, self.img.height()*self.scale-2, self.bbrush)
         if self.scale > 1:
-            dc.save()
-            dc.translate(self.tx, self.ty)
-            dc.scale(self.scale, self.scale)
-            dc.drawImage(0, 0, self.img)
-            dc.restore()
+            xf = QTransform().translate(self.tx, self.ty).scale(self.scale, self.scale)
+            dc.drawImage(QRectF(self.rect()), self.img, xf.inverted()[0].mapRect(QRectF(self.rect())))
         else:
             if self.scaled is None or self.scaled[0] != self.scale:
                 sw = int(self.img.width() * self.scale)


### PR DESCRIPTION
Use drawImage rect-to-rect stretch overload instead of applying a
QPainter-wide transformation; it yields way a better result in terms of
precision (e.g. for the pixel or selection tool)