### PR TITLE
Use shift/ctrl to go forward/backward faster in images list (shift = 10×, ctrl = 100×)

### DIFF
--- a/iview
+++ b/iview
@@ -75,6 +75,7 @@ class Viewer(QW):
         self.load(0)
 
     def load(self, index):
+        index = index % len(self.imglist)
         reader = QImageReader(self.imglist[index])
         reader.setAutoTransform(True)
         img = reader.read()
@@ -180,18 +181,23 @@ class Viewer(QW):
         self.update()
 
     def keyPressEvent(self, e):
+        inc = 1
+        if int(e.modifiers()) & Qt.ShiftModifier:
+            inc *= 10
+        if int(e.modifiers()) & Qt.ControlModifier:
+            inc *= 100
         for t in self.tools:
             if t.key(e):
                 self.update()
                 return
         if e.key() == Qt.Key_Right:
             w, h = self.img.width(), self.img.height()
-            self.load(min(1, len(self.imglist) - 1))
+            self.load(inc)
             if (w, h) != (self.img.width(), self.img.height()):
                 self.zoomAll()
         elif e.key() == Qt.Key_Left:
             w, h = self.img.width(), self.img.height()
-            self.load(len(self.imglist) - 1)
+            self.load(-inc)
             if (w, h) != (self.img.width(), self.img.height()):
                 self.zoomAll()
         elif e.key() == Qt.Key_1:


### PR DESCRIPTION
useful e.g. if you have a lot of frames from a video exploded on many files, so it's nice to have a "fast forward" function